### PR TITLE
Implement basic Angular 19 frontend

### DIFF
--- a/Frontend/src/app/app.component.html
+++ b/Frontend/src/app/app.component.html
@@ -1,0 +1,1 @@
+<router-outlet></router-outlet>

--- a/Frontend/src/app/app.component.spec.ts
+++ b/Frontend/src/app/app.component.spec.ts
@@ -14,16 +14,10 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have the 'MySkilledCV_Frontend' title`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('MySkilledCV_Frontend');
-  });
-
-  it('should render title', () => {
+  it('should render router outlet', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, MySkilledCV_Frontend');
+    expect(compiled.querySelector('router-outlet')).not.toBeNull();
   });
 });

--- a/Frontend/src/app/app.component.ts
+++ b/Frontend/src/app/app.component.ts
@@ -7,6 +7,4 @@ import { RouterOutlet } from '@angular/router';
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
 })
-export class AppComponent {
-  title = 'MySkilledCV_Frontend';
-}
+export class AppComponent {}

--- a/Frontend/src/app/app.config.ts
+++ b/Frontend/src/app/app.config.ts
@@ -1,9 +1,17 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient, withInterceptorsFromDi, HTTP_INTERCEPTORS } from '@angular/common/http';
 
 import { routes } from './app.routes';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
+import { JwtInterceptor } from './interceptors/jwt.interceptor';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes), provideClientHydration(withEventReplay())]
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(routes),
+    provideClientHydration(withEventReplay()),
+    provideHttpClient(withInterceptorsFromDi()),
+    { provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true }
+  ]
 };

--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -1,3 +1,21 @@
 import { Routes } from '@angular/router';
+import { HomeComponent } from './pages/home/home.component';
+import { LoginComponent } from './pages/login/login.component';
+import { RegisterComponent } from './pages/register/register.component';
+import { CompanyDashboardComponent } from './pages/dashboard/company/company.component';
+import { UserDashboardComponent } from './pages/dashboard/user/user.component';
+import { authGuard } from './guards/auth.guard';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: '', component: HomeComponent },
+  { path: 'login', component: LoginComponent },
+  { path: 'register', component: RegisterComponent },
+  {
+    path: 'dashboard',
+    canActivate: [authGuard],
+    children: [
+      { path: '', component: CompanyDashboardComponent }, // default to company for demo
+      { path: 'user', component: UserDashboardComponent },
+    ],
+  },
+];

--- a/Frontend/src/app/components/feature-card.component.ts
+++ b/Frontend/src/app/components/feature-card.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-feature-card',
+  standalone: true,
+  template: `
+    <div class="bg-white dark:bg-gray-800 p-6 rounded shadow hover:scale-105 hover:ring-2 ring-indigo-600 transition-all duration-300">
+      <h3 class="text-lg font-bold mb-2">{{title}}</h3>
+      <p class="text-sm text-gray-600 dark:text-gray-300">{{description}}</p>
+    </div>
+  `
+})
+export class FeatureCardComponent {
+  @Input() title = '';
+  @Input() description = '';
+}

--- a/Frontend/src/app/components/header.component.ts
+++ b/Frontend/src/app/components/header.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-header',
+  standalone: true,
+  imports: [RouterModule],
+  template: `
+    <header class="flex items-center justify-between px-6 py-4 bg-white dark:bg-gray-900 shadow">
+      <a routerLink="/" class="text-2xl font-bold text-indigo-600">MySkilledCV</a>
+      <nav class="hidden md:flex gap-6 text-sm font-medium">
+        <a routerLink="/#features" class="hover:text-indigo-600 transition-colors">Features</a>
+        <a routerLink="/#pricing" class="hover:text-indigo-600 transition-colors">Pricing</a>
+        <a routerLink="/#contact" class="hover:text-indigo-600 transition-colors">Contact</a>
+      </nav>
+      <div class="flex gap-4">
+        <a routerLink="/login" class="px-4 py-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">Login</a>
+        <a routerLink="/register" class="px-4 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-700 transition-colors">Register</a>
+      </div>
+    </header>
+  `
+})
+export class HeaderComponent {}

--- a/Frontend/src/app/components/resume-card.component.ts
+++ b/Frontend/src/app/components/resume-card.component.ts
@@ -1,0 +1,20 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'app-resume-card',
+  standalone: true,
+  template: `
+    <div class="p-4 border rounded flex justify-between items-center hover:ring-2 ring-indigo-600 transition-all duration-300">
+      <div>
+        <h4 class="font-semibold">{{name}}</h4>
+        <p class="text-sm text-gray-600 dark:text-gray-300">Score: {{score}}</p>
+      </div>
+      <button class="text-indigo-600 hover:underline" (click)="view.emit()">View</button>
+    </div>
+  `
+})
+export class ResumeCardComponent {
+  @Input() name = '';
+  @Input() score?: number;
+  @Output() view = new EventEmitter<void>();
+}

--- a/Frontend/src/app/components/sidebar.component.ts
+++ b/Frontend/src/app/components/sidebar.component.ts
@@ -1,0 +1,21 @@
+import { Component, Input } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-sidebar',
+  standalone: true,
+  imports: [RouterModule],
+  template: `
+    <aside class="w-64 bg-gray-50 dark:bg-gray-900 min-h-screen p-6">
+      <nav class="flex flex-col gap-4 text-sm">
+        <a routerLink="." class="font-semibold" routerLinkActive="text-indigo-600">Dashboard</a>
+        <a *ngIf="role === 'company'" routerLink="jobs" routerLinkActive="text-indigo-600">Job Postings</a>
+        <a *ngIf="role === 'company'" routerLink="candidates" routerLinkActive="text-indigo-600">Candidates</a>
+        <a routerLink="settings" routerLinkActive="text-indigo-600">Settings</a>
+      </nav>
+    </aside>
+  `
+})
+export class SidebarComponent {
+  @Input() role: 'company' | 'user' = 'user';
+}

--- a/Frontend/src/app/components/step-card.component.ts
+++ b/Frontend/src/app/components/step-card.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-step-card',
+  standalone: true,
+  template: `
+    <div class="flex flex-col items-center text-center gap-2">
+      <div class="text-4xl font-bold text-indigo-600">{{step}}</div>
+      <h4 class="font-semibold">{{title}}</h4>
+      <p class="text-sm text-gray-600 dark:text-gray-300">{{description}}</p>
+    </div>
+  `
+})
+export class StepCardComponent {
+  @Input() step = 1;
+  @Input() title = '';
+  @Input() description = '';
+}

--- a/Frontend/src/app/guards/auth.guard.ts
+++ b/Frontend/src/app/guards/auth.guard.ts
@@ -1,0 +1,13 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+export const authGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+  if (!auth.isAuthenticated) {
+    router.navigate(['/login']);
+    return false;
+  }
+  return true;
+};

--- a/Frontend/src/app/interceptors/jwt.interceptor.ts
+++ b/Frontend/src/app/interceptors/jwt.interceptor.ts
@@ -1,0 +1,16 @@
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { AuthService } from '../services/auth.service';
+
+@Injectable()
+export class JwtInterceptor implements HttpInterceptor {
+  private auth = inject(AuthService);
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const token = this.auth.token;
+    if (token) {
+      req = req.clone({ setHeaders: { Authorization: `Bearer ${token}` } });
+    }
+    return next.handle(req);
+  }
+}

--- a/Frontend/src/app/pages/dashboard/company/company.component.ts
+++ b/Frontend/src/app/pages/dashboard/company/company.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SidebarComponent } from '../../../components/sidebar.component';
+import { ResumeCardComponent } from '../../../components/resume-card.component';
+
+@Component({
+  selector: 'app-company-dashboard',
+  standalone: true,
+  imports: [CommonModule, SidebarComponent, ResumeCardComponent],
+  template: `
+    <div class="flex">
+      <app-sidebar role="company"></app-sidebar>
+      <main class="flex-1 p-6 grid gap-6">
+        <h1 class="text-2xl font-bold">Company Dashboard</h1>
+        <section class="border rounded p-4">
+          <h2 class="font-semibold mb-2">Uploaded Resumes</h2>
+          <app-resume-card name="John Doe" [score]="85"></app-resume-card>
+        </section>
+      </main>
+    </div>
+  `
+})
+export class CompanyDashboardComponent {}

--- a/Frontend/src/app/pages/dashboard/user/user.component.ts
+++ b/Frontend/src/app/pages/dashboard/user/user.component.ts
@@ -1,0 +1,48 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SidebarComponent } from '../../../components/sidebar.component';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+
+@Component({
+  selector: 'app-user-dashboard',
+  standalone: true,
+  imports: [CommonModule, SidebarComponent, ReactiveFormsModule],
+  template: `
+    <div class="flex">
+      <app-sidebar role="user"></app-sidebar>
+      <main class="flex-1 p-6 grid gap-6">
+        <h1 class="text-2xl font-bold">Your CV</h1>
+        <form [formGroup]="form" (ngSubmit)="onSubmit()" class="flex flex-col gap-4 border rounded p-4">
+          <input type="file" (change)="onFile($event)" />
+          <input formControlName="job" type="text" placeholder="Target Job" class="p-2 border rounded" />
+          <textarea formControlName="skills" placeholder="Required Skills" class="p-2 border rounded"></textarea>
+          <button class="bg-indigo-600 text-white py-2 rounded hover:bg-indigo-700 transition">Analyze</button>
+        </form>
+        <div *ngIf="result" class="border rounded p-4">
+          <h2 class="font-semibold mb-2">AI Result</h2>
+          <p>Score: {{result.score}}</p>
+          <p>{{result.summary}}</p>
+        </div>
+      </main>
+    </div>
+  `
+})
+export class UserDashboardComponent {
+  form: ReturnType<FormBuilder['group']>;
+  file?: File;
+  result?: { score: number; summary: string };
+  constructor(private fb: FormBuilder) {
+    this.form = this.fb.group({
+      job: ['', Validators.required],
+      skills: ['', Validators.required],
+    });
+  }
+  onFile(e: Event) {
+    const input = e.target as HTMLInputElement;
+    this.file = input.files?.[0];
+  }
+  onSubmit() {
+    if (this.form.invalid || !this.file) return;
+    this.result = { score: 90, summary: 'Great fit for the position!' };
+  }
+}

--- a/Frontend/src/app/pages/home/home.component.ts
+++ b/Frontend/src/app/pages/home/home.component.ts
@@ -1,0 +1,31 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HeaderComponent } from '../../components/header.component';
+import { FeatureCardComponent } from '../../components/feature-card.component';
+import { StepCardComponent } from '../../components/step-card.component';
+
+@Component({
+  selector: 'app-home',
+  standalone: true,
+  imports: [CommonModule, HeaderComponent, FeatureCardComponent, StepCardComponent],
+  template: `
+    <app-header></app-header>
+    <section class="text-center py-20 bg-gray-50 dark:bg-gray-800">
+      <h1 class="text-4xl font-bold mb-4">AI-Powered Resume Analysis</h1>
+      <p class="text-gray-600 dark:text-gray-300 mb-6">Improve your hiring process and land your dream job.</p>
+      <a routerLink="/register" class="px-6 py-3 bg-indigo-600 text-white rounded hover:scale-105 transition-all duration-300">Get Started</a>
+    </section>
+    <section id="features" class="py-12 px-6 grid md:grid-cols-3 gap-6">
+      <app-feature-card title="Upload Resumes" description="Easily upload PDF resumes for analysis"></app-feature-card>
+      <app-feature-card title="AI Insights" description="Leverage AI to rank and score candidates"></app-feature-card>
+      <app-feature-card title="Job Management" description="Track job listings and candidates"></app-feature-card>
+    </section>
+    <section id="how" class="py-12 bg-gray-100 dark:bg-gray-900 px-6 grid md:grid-cols-3 gap-6 text-center">
+      <app-step-card [step]="1" title="Create Job" description="Add job details and required skills"></app-step-card>
+      <app-step-card [step]="2" title="Upload CVs" description="Drag and drop resumes into the dashboard"></app-step-card>
+      <app-step-card [step]="3" title="Get Insights" description="View ranking and AI suggestions"></app-step-card>
+    </section>
+    <footer class="py-6 text-center text-sm text-gray-500 dark:text-gray-400">© 2025 MySkilledCV</footer>
+  `
+})
+export class HomeComponent {}

--- a/Frontend/src/app/pages/login/login.component.ts
+++ b/Frontend/src/app/pages/login/login.component.ts
@@ -1,0 +1,36 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { AuthService } from '../../services/auth.service';
+import { Router } from '@angular/router';
+import { HeaderComponent } from '../../components/header.component';
+
+@Component({
+  selector: 'app-login',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, HeaderComponent],
+  template: `
+    <app-header></app-header>
+    <div class="flex justify-center items-center py-20">
+      <form [formGroup]="form" (ngSubmit)="onSubmit()" class="bg-white dark:bg-gray-800 p-6 rounded shadow w-full max-w-md flex flex-col gap-4">
+        <h1 class="text-2xl font-bold mb-2">Login</h1>
+        <input formControlName="email" type="email" placeholder="Email" class="p-2 border rounded" />
+        <input formControlName="password" type="password" placeholder="Password" class="p-2 border rounded" />
+        <button type="submit" class="bg-indigo-600 text-white py-2 rounded hover:bg-indigo-700 transition">Login</button>
+      </form>
+    </div>
+  `
+})
+export class LoginComponent {
+  form: ReturnType<FormBuilder['group']>;
+  constructor(private fb: FormBuilder, private auth: AuthService, private router: Router) {
+    this.form = this.fb.group({
+      email: ['', [Validators.required, Validators.email]],
+      password: ['', Validators.required],
+    });
+  }
+  onSubmit() {
+    if (this.form.invalid) return;
+    this.auth.login(this.form.value).subscribe(() => this.router.navigate(['/dashboard']));
+  }
+}

--- a/Frontend/src/app/pages/register/register.component.ts
+++ b/Frontend/src/app/pages/register/register.component.ts
@@ -1,0 +1,36 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { AuthService } from '../../services/auth.service';
+import { Router } from '@angular/router';
+import { HeaderComponent } from '../../components/header.component';
+
+@Component({
+  selector: 'app-register',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, HeaderComponent],
+  template: `
+    <app-header></app-header>
+    <div class="flex justify-center items-center py-20">
+      <form [formGroup]="form" (ngSubmit)="onSubmit()" class="bg-white dark:bg-gray-800 p-6 rounded shadow w-full max-w-md flex flex-col gap-4">
+        <h1 class="text-2xl font-bold mb-2">Register</h1>
+        <input formControlName="email" type="email" placeholder="Email" class="p-2 border rounded" />
+        <input formControlName="password" type="password" placeholder="Password" class="p-2 border rounded" />
+        <button type="submit" class="bg-indigo-600 text-white py-2 rounded hover:bg-indigo-700 transition">Create Account</button>
+      </form>
+    </div>
+  `
+})
+export class RegisterComponent {
+  form: ReturnType<FormBuilder['group']>;
+  constructor(private fb: FormBuilder, private auth: AuthService, private router: Router) {
+    this.form = this.fb.group({
+      email: ['', [Validators.required, Validators.email]],
+      password: ['', Validators.required],
+    });
+  }
+  onSubmit() {
+    if (this.form.invalid) return;
+    this.auth.register(this.form.value).subscribe(() => this.router.navigate(['/dashboard']));
+  }
+}

--- a/Frontend/src/app/services/auth.service.ts
+++ b/Frontend/src/app/services/auth.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Router } from '@angular/router';
+import { tap } from 'rxjs/operators';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private api = '/api/auth';
+
+  constructor(private http: HttpClient, private router: Router) {}
+
+  login(credentials: { email: string; password: string }) {
+    return this.http.post<{ token: string }>(`${this.api}/login`, credentials).pipe(
+      tap(res => localStorage.setItem('token', res.token))
+    );
+  }
+
+  register(data: { email: string; password: string }) {
+    return this.http.post<{ token: string }>(`${this.api}/register`, data).pipe(
+      tap(res => localStorage.setItem('token', res.token))
+    );
+  }
+
+  logout() {
+    localStorage.removeItem('token');
+    this.router.navigate(['/login']);
+  }
+
+  get token() {
+    return localStorage.getItem('token');
+  }
+
+  get isAuthenticated() {
+    return !!this.token;
+  }
+}

--- a/Frontend/src/app/services/job.service.ts
+++ b/Frontend/src/app/services/job.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({ providedIn: 'root' })
+export class JobService {
+  private api = '/api/jobs';
+
+  constructor(private http: HttpClient) {}
+
+  getAll() {
+    return this.http.get(`${this.api}`);
+  }
+}

--- a/Frontend/src/app/services/resume.service.ts
+++ b/Frontend/src/app/services/resume.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({ providedIn: 'root' })
+export class ResumeService {
+  private api = '/api/resumes';
+
+  constructor(private http: HttpClient) {}
+
+  upload(file: File) {
+    const formData = new FormData();
+    formData.append('file', file);
+    return this.http.post(`${this.api}/upload`, formData);
+  }
+
+  getAll() {
+    return this.http.get(`${this.api}`);
+  }
+}

--- a/Frontend/src/styles.css
+++ b/Frontend/src/styles.css
@@ -1,1 +1,7 @@
 @import "tailwindcss";
+
+@layer base {
+  body {
+    @apply bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100;
+  }
+}

--- a/Frontend/tailwind.config.js
+++ b/Frontend/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './src/**/*.{html,ts}'
+  ],
+  darkMode: 'class',
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- scaffold Angular 19 frontend with TailwindCSS 4
- add landing page, login/register pages and dashboards
- implement header, sidebar and other UI components
- add basic auth service with JWT support
- provide router, guard and interceptor configuration

## Testing
- `npm run build`
- `npm test -- --watch=false` *(fails: No Chrome binary available)*

------
https://chatgpt.com/codex/tasks/task_e_685e7f908fa0832891be54ab2af9b22a