### PR TITLE
Add basic resume analysis endpoint and frontend page

### DIFF
--- a/Backend/src/main/java/com/mehdi/MySkilledCV/contoller/ResumeController.java
+++ b/Backend/src/main/java/com/mehdi/MySkilledCV/contoller/ResumeController.java
@@ -1,0 +1,34 @@
+package com.mehdi.MySkilledCV.contoller;
+
+import com.mehdi.MySkilledCV.model.AnalysisResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.security.Principal;
+
+@RestController
+@RequestMapping("/api/resumes")
+@RequiredArgsConstructor
+public class ResumeController {
+
+    @PostMapping(value = "/analyze", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public AnalysisResponse analyze(
+            @RequestPart("file") MultipartFile file,
+            @RequestParam("job") String job,
+            @RequestParam("skills") String skills,
+            Principal principal
+    ) {
+        if (file.isEmpty() || !"application/pdf".equals(file.getContentType())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "PDF required");
+        }
+        if (file.getSize() > 2_000_000) { // 2 MB max
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "File too large");
+        }
+        // TODO integrate Gemini API
+        return new AnalysisResponse(90, "Great fit for " + job);
+    }
+}

--- a/Backend/src/main/java/com/mehdi/MySkilledCV/model/AnalysisResponse.java
+++ b/Backend/src/main/java/com/mehdi/MySkilledCV/model/AnalysisResponse.java
@@ -1,0 +1,11 @@
+package com.mehdi.MySkilledCV.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AnalysisResponse {
+    private int score;
+    private String summary;
+}

--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -4,12 +4,14 @@ import { LoginComponent } from './pages/login/login.component';
 import { RegisterComponent } from './pages/register/register.component';
 import { CompanyDashboardComponent } from './pages/dashboard/company/company.component';
 import { UserDashboardComponent } from './pages/dashboard/user/user.component';
+import { AnalysisComponent } from './pages/analysis/analysis.component';
 import { authGuard } from './guards/auth.guard';
 
 export const routes: Routes = [
   { path: '', component: HomeComponent },
   { path: 'login', component: LoginComponent },
   { path: 'register', component: RegisterComponent },
+  { path: 'analysis', component: AnalysisComponent, canActivate: [authGuard] },
   {
     path: 'dashboard',
     canActivate: [authGuard],

--- a/Frontend/src/app/pages/analysis/analysis.component.ts
+++ b/Frontend/src/app/pages/analysis/analysis.component.ts
@@ -1,0 +1,32 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-analysis-result',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="p-6 max-w-xl mx-auto">
+      <h1 class="text-2xl font-bold mb-4">Résultat de l'analyse IA</h1>
+      <p *ngIf="!result">Aucun résultat.</p>
+      <div *ngIf="result" class="space-y-2">
+        <p class="font-semibold">Score: {{ result.score }}</p>
+        <p>{{ result.summary }}</p>
+      </div>
+      <button (click)="back()" class="mt-4 bg-indigo-600 text-white py-2 px-4 rounded">Retour</button>
+    </div>
+  `
+})
+export class AnalysisComponent {
+  result: any;
+
+  constructor(private router: Router) {
+    const nav = this.router.getCurrentNavigation();
+    this.result = nav?.extras.state;
+  }
+
+  back() {
+    this.router.navigate(['/dashboard/user']);
+  }
+}

--- a/Frontend/src/app/pages/dashboard/user/user.component.ts
+++ b/Frontend/src/app/pages/dashboard/user/user.component.ts
@@ -2,6 +2,8 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SidebarComponent } from '../../../components/sidebar.component';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { ResumeService } from '../../../services/resume.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-user-dashboard',
@@ -18,11 +20,6 @@ import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
           <textarea formControlName="skills" placeholder="Required Skills" class="p-2 border rounded"></textarea>
           <button class="bg-indigo-600 text-white py-2 rounded hover:bg-indigo-700 transition">Analyze</button>
         </form>
-        <div *ngIf="result" class="border rounded p-4">
-          <h2 class="font-semibold mb-2">AI Result</h2>
-          <p>Score: {{result.score}}</p>
-          <p>{{result.summary}}</p>
-        </div>
       </main>
     </div>
   `
@@ -30,8 +27,7 @@ import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 export class UserDashboardComponent {
   form: ReturnType<FormBuilder['group']>;
   file?: File;
-  result?: { score: number; summary: string };
-  constructor(private fb: FormBuilder) {
+  constructor(private fb: FormBuilder, private resume: ResumeService, private router: Router) {
     this.form = this.fb.group({
       job: ['', Validators.required],
       skills: ['', Validators.required],
@@ -43,6 +39,9 @@ export class UserDashboardComponent {
   }
   onSubmit() {
     if (this.form.invalid || !this.file) return;
-    this.result = { score: 90, summary: 'Great fit for the position!' };
+    const { job, skills } = this.form.value;
+    this.resume.analyze(this.file, job, skills).subscribe(res => {
+      this.router.navigate(['/analysis'], { state: res });
+    });
   }
 }

--- a/Frontend/src/app/services/resume.service.ts
+++ b/Frontend/src/app/services/resume.service.ts
@@ -13,6 +13,14 @@ export class ResumeService {
     return this.http.post(`${this.api}/upload`, formData);
   }
 
+  analyze(file: File, job: string, skills: string) {
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('job', job);
+    formData.append('skills', skills);
+    return this.http.post<{ score: number; summary: string }>(`${this.api}/analyze`, formData);
+  }
+
   getAll() {
     return this.http.get(`${this.api}`);
   }


### PR DESCRIPTION
## Summary
- add `AnalysisResponse` model and `ResumeController` with `/api/resumes/analyze`
- update Angular dashboard to send resume for analysis and show results
- expose new `analyze` method in `ResumeService`
- add analysis result page and route

## Testing
- `./mvnw -q test` *(fails: Failed to fetch maven dependencies)*
- `npm test --silent` *(fails: PostCSS plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_686009f97e508328b6c732a44e4f837b