### PR TITLE
Add frontend proxy and backend CORS

### DIFF
--- a/Backend/src/main/java/com/mehdi/MySkilledCV/config/SecurityConfig.java
+++ b/Backend/src/main/java/com/mehdi/MySkilledCV/config/SecurityConfig.java
@@ -13,6 +13,11 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
@@ -25,6 +30,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.POST, "/api/auth/**").permitAll()
@@ -44,5 +50,17 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:4200"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/Frontend/README.md
+++ b/Frontend/README.md
@@ -10,6 +10,10 @@ To start a local development server, run:
 ng serve
 ```
 
+The dev server proxies API requests starting with `/api` to the Spring Boot
+backend on `http://localhost:8080`. Ensure the backend is running so the
+frontend can communicate with it.
+
 Once the server is running, open your browser and navigate to `http://localhost:4200/`. The application will automatically reload whenever you modify any of the source files.
 
 ## Code scaffolding

--- a/Frontend/angular.json
+++ b/Frontend/angular.json
@@ -62,6 +62,9 @@
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "proxyConfig": "proxy.conf.json"
+          },
           "configurations": {
             "production": {
               "buildTarget": "MySkilledCV_Frontend:build:production"

--- a/Frontend/proxy.conf.json
+++ b/Frontend/proxy.conf.json
@@ -1,0 +1,7 @@
+{
+  "/api": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true
+  }
+}


### PR DESCRIPTION
## Summary
- proxy API calls from Angular dev server to Spring Boot using `proxy.conf.json`
- enable CORS in Spring Security
- document proxy behaviour in frontend README

## Testing
- `./mvnw -q test` *(fails: network access for dependencies)*
- `npm test` *(fails: PostCSS plugin dependency error)*

------
https://chatgpt.com/codex/tasks/task_e_68600d55466883288fb84aff812d7ecd