### PR TITLE
Implement resume upload and job APIs

### DIFF
--- a/Backend/src/main/java/com/mehdi/MySkilledCV/config/DataInitializer.java
+++ b/Backend/src/main/java/com/mehdi/MySkilledCV/config/DataInitializer.java
@@ -1,0 +1,25 @@
+package com.mehdi.MySkilledCV.config;
+
+import com.mehdi.MySkilledCV.model.Job;
+import com.mehdi.MySkilledCV.repository.JobRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class DataInitializer {
+
+    private final JobRepository jobRepository;
+
+    @Bean
+    CommandLineRunner initJobs() {
+        return args -> {
+            if (jobRepository.count() == 0) {
+                jobRepository.save(new Job(null, "Software Engineer", "Develop features"));
+                jobRepository.save(new Job(null, "Project Manager", "Manage projects"));
+            }
+        };
+    }
+}

--- a/Backend/src/main/java/com/mehdi/MySkilledCV/contoller/JobController.java
+++ b/Backend/src/main/java/com/mehdi/MySkilledCV/contoller/JobController.java
@@ -1,0 +1,23 @@
+package com.mehdi.MySkilledCV.contoller;
+
+import com.mehdi.MySkilledCV.model.Job;
+import com.mehdi.MySkilledCV.service.JobService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/jobs")
+@RequiredArgsConstructor
+public class JobController {
+
+    private final JobService jobService;
+
+    @GetMapping
+    public List<Job> getAll() {
+        return jobService.getAll();
+    }
+}

--- a/Backend/src/main/java/com/mehdi/MySkilledCV/contoller/ResumeController.java
+++ b/Backend/src/main/java/com/mehdi/MySkilledCV/contoller/ResumeController.java
@@ -1,6 +1,10 @@
 package com.mehdi.MySkilledCV.contoller;
 
 import com.mehdi.MySkilledCV.model.AnalysisResponse;
+import com.mehdi.MySkilledCV.model.User;
+import com.mehdi.MySkilledCV.service.ResumeService;
+import com.mehdi.MySkilledCV.service.AnalysisService;
+import com.mehdi.MySkilledCV.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -15,6 +19,10 @@ import java.security.Principal;
 @RequiredArgsConstructor
 public class ResumeController {
 
+    private final ResumeService resumeService;
+    private final AnalysisService analysisService;
+    private final UserRepository userRepository;
+
     @PostMapping(value = "/analyze", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public AnalysisResponse analyze(
             @RequestPart("file") MultipartFile file,
@@ -28,7 +36,21 @@ public class ResumeController {
         if (file.getSize() > 2_000_000) { // 2 MB max
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "File too large");
         }
-        // TODO integrate Gemini API
-        return new AnalysisResponse(90, "Great fit for " + job);
+        return analysisService.analyze(file, job, skills);
+    }
+
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public void upload(@RequestPart("file") MultipartFile file, Principal principal) {
+        if (file.isEmpty() || !"application/pdf".equals(file.getContentType())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "PDF required");
+        }
+        User user = userRepository.findByEmail(principal.getName())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED));
+        resumeService.upload(file, user);
+    }
+
+    @GetMapping
+    public java.util.List<com.mehdi.MySkilledCV.model.Resume> getAll() {
+        return resumeService.getAll();
     }
 }

--- a/Backend/src/main/java/com/mehdi/MySkilledCV/model/Job.java
+++ b/Backend/src/main/java/com/mehdi/MySkilledCV/model/Job.java
@@ -1,0 +1,20 @@
+package com.mehdi.MySkilledCV.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "jobs")
+public class Job {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private String title;
+    private String description;
+}

--- a/Backend/src/main/java/com/mehdi/MySkilledCV/model/Resume.java
+++ b/Backend/src/main/java/com/mehdi/MySkilledCV/model/Resume.java
@@ -1,0 +1,26 @@
+package com.mehdi.MySkilledCV.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "resumes")
+public class Resume {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private String fileName;
+
+    @Lob
+    private byte[] data;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/Backend/src/main/java/com/mehdi/MySkilledCV/repository/JobRepository.java
+++ b/Backend/src/main/java/com/mehdi/MySkilledCV/repository/JobRepository.java
@@ -1,0 +1,7 @@
+package com.mehdi.MySkilledCV.repository;
+
+import com.mehdi.MySkilledCV.model.Job;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JobRepository extends JpaRepository<Job, Long> {
+}

--- a/Backend/src/main/java/com/mehdi/MySkilledCV/repository/ResumeRepository.java
+++ b/Backend/src/main/java/com/mehdi/MySkilledCV/repository/ResumeRepository.java
@@ -1,0 +1,7 @@
+package com.mehdi.MySkilledCV.repository;
+
+import com.mehdi.MySkilledCV.model.Resume;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ResumeRepository extends JpaRepository<Resume, Long> {
+}

--- a/Backend/src/main/java/com/mehdi/MySkilledCV/service/AnalysisService.java
+++ b/Backend/src/main/java/com/mehdi/MySkilledCV/service/AnalysisService.java
@@ -1,0 +1,14 @@
+package com.mehdi.MySkilledCV.service;
+
+import com.mehdi.MySkilledCV.model.AnalysisResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+public class AnalysisService {
+    public AnalysisResponse analyze(MultipartFile file, String job, String skills) {
+        int keywords = skills == null ? 0 : skills.split(",").length;
+        int score = Math.min(100, 50 + keywords * 10);
+        return new AnalysisResponse(score, "Great fit for " + job);
+    }
+}

--- a/Backend/src/main/java/com/mehdi/MySkilledCV/service/JobService.java
+++ b/Backend/src/main/java/com/mehdi/MySkilledCV/service/JobService.java
@@ -1,0 +1,19 @@
+package com.mehdi.MySkilledCV.service;
+
+import com.mehdi.MySkilledCV.model.Job;
+import com.mehdi.MySkilledCV.repository.JobRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class JobService {
+
+    private final JobRepository jobRepository;
+
+    public List<Job> getAll() {
+        return jobRepository.findAll();
+    }
+}

--- a/Backend/src/main/java/com/mehdi/MySkilledCV/service/ResumeService.java
+++ b/Backend/src/main/java/com/mehdi/MySkilledCV/service/ResumeService.java
@@ -1,0 +1,34 @@
+package com.mehdi.MySkilledCV.service;
+
+import com.mehdi.MySkilledCV.model.Resume;
+import com.mehdi.MySkilledCV.model.User;
+import com.mehdi.MySkilledCV.repository.ResumeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ResumeService {
+
+    private final ResumeRepository resumeRepository;
+
+    public void upload(MultipartFile file, User user) {
+        try {
+            Resume resume = new Resume();
+            resume.setFileName(file.getOriginalFilename());
+            resume.setData(file.getBytes());
+            resume.setUser(user);
+            resumeRepository.save(resume);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to store resume", e);
+        }
+    }
+
+    public List<Resume> getAll() {
+        return resumeRepository.findAll();
+    }
+}


### PR DESCRIPTION
## Summary
- allow users to upload and list resumes
- provide job listing endpoint and seed data
- return simple analysis result from a new `AnalysisService`

## Testing
- `mvn -q -f Backend/pom.xml test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68601239360c8328b788988ecdf04232