### PR TITLE
Integrate Gemini API and upload

### DIFF
--- a/Backend/src/main/java/com/mehdi/MySkilledCV/service/AnalysisService.java
+++ b/Backend/src/main/java/com/mehdi/MySkilledCV/service/AnalysisService.java
@@ -1,14 +1,20 @@
 package com.mehdi.MySkilledCV.service;
 
 import com.mehdi.MySkilledCV.model.AnalysisResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
+@RequiredArgsConstructor
 public class AnalysisService {
+
+    private final GeminiService geminiService;
+
     public AnalysisResponse analyze(MultipartFile file, String job, String skills) {
         int keywords = skills == null ? 0 : skills.split(",").length;
         int score = Math.min(100, 50 + keywords * 10);
-        return new AnalysisResponse(score, "Great fit for " + job);
+        String summary = geminiService.generateSummary(file.getOriginalFilename(), job, skills);
+        return new AnalysisResponse(score, summary.isBlank() ? "Great fit for " + job : summary);
     }
 }

--- a/Backend/src/main/java/com/mehdi/MySkilledCV/service/GeminiService.java
+++ b/Backend/src/main/java/com/mehdi/MySkilledCV/service/GeminiService.java
@@ -1,0 +1,51 @@
+package com.mehdi.MySkilledCV.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Service
+public class GeminiService {
+
+    @Value("${gemini.api.key:}")
+    private String apiKey;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public String generateSummary(String resumeText, String job, String skills) {
+        if (apiKey == null || apiKey.isEmpty()) {
+            return "Gemini API key not configured";
+        }
+        String url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=" + apiKey;
+
+        Map<String, Object> payload = Map.of(
+                "contents", Collections.singletonList(
+                        Map.of("parts", Collections.singletonList(
+                                Map.of("text", "Summarize this resume for a " + job + " position. Required skills: " + skills + "\n" + resumeText)
+                        ))
+                )
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(payload, headers);
+
+        Map response = restTemplate.postForObject(url, entity, Map.class);
+        if (response == null) return "";
+        try {
+            Map firstCandidate = ((java.util.List<Map>) response.get("candidates")).get(0);
+            Map content = (Map) firstCandidate.get("content");
+            java.util.List<Map> parts = (java.util.List<Map>) content.get("parts");
+            return parts.get(0).get("text").toString();
+        } catch (Exception e) {
+            return "";
+        }
+    }
+}

--- a/Backend/src/main/resources/application.properties
+++ b/Backend/src/main/resources/application.properties
@@ -9,3 +9,4 @@ spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 app.jwt.secret=97825f18b6de42549b95cdf3e2b55833451f81502dc74903b91a72d81575fb43
 app.jwt.expiration=3600000
+gemini.api.key=

--- a/Frontend/src/app/pages/dashboard/user/user.component.ts
+++ b/Frontend/src/app/pages/dashboard/user/user.component.ts
@@ -40,8 +40,10 @@ export class UserDashboardComponent {
   onSubmit() {
     if (this.form.invalid || !this.file) return;
     const { job, skills } = this.form.value;
-    this.resume.analyze(this.file, job, skills).subscribe(res => {
-      this.router.navigate(['/analysis'], { state: res });
+    this.resume.upload(this.file).subscribe(() => {
+      this.resume.analyze(this.file, job, skills).subscribe(res => {
+        this.router.navigate(['/analysis'], { state: res });
+      });
     });
   }
 }


### PR DESCRIPTION
## Summary
- integrate Google Gemini API via `GeminiService`
- call Gemini from `AnalysisService`
- enable `/upload` usage in the dashboard
- add a configuration placeholder for the Gemini API key

## Testing
- `mvnw test` *(fails: network access required)*
- `npm test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68601878d9188328abd76e896168bc12